### PR TITLE
Replace broken eest repo link with EOF test case link

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@
 										<strong>EOF Tests</strong>
 										<div><a href="https://github.com/ethereum/tests/tree/develop/src/EOFTestsFiller">- Validation Tests</a></div>
 										<div><a href="https://github.com/ethereum/tests/tree/develop/src/EIPTestsFiller/StateTests/stEOF">- Execution Tests</a></div>
-										<div><a href="https://github.com/ethereum/execution-spec-tests/tree/main/tests/prague/eip7692_eof_v1">- Execution Spec Tests</a></div>
+										<div><a href="https://ethereum.github.io/execution-spec-tests/main/tests/osaka/eip7692_eof_v1/">- Execution Spec Tests</a></div>
 									</li>
 								</ul>
 							</section>


### PR DESCRIPTION
Replaces the broken link to the execution-spec-tests repo by linking to the EOF test cases in the online docs "Test Case Reference" (links to source are provided there).