### PR TITLE
Remove link to ethereum/tests `stEOF`

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,7 +313,6 @@
 										<span class="icon solid fa-code-branch"></span>
 										<strong>EOF Tests</strong>
 										<div><a href="https://github.com/ethereum/tests/tree/develop/src/EOFTestsFiller">- Validation Tests</a></div>
-										<div><a href="https://github.com/ethereum/tests/tree/develop/src/EIPTestsFiller/StateTests/stEOF">- Execution Tests</a></div>
 										<div><a href="https://ethereum.github.io/execution-spec-tests/main/tests/osaka/eip7692_eof_v1/">- Execution Spec Tests</a></div>
 									</li>
 								</ul>


### PR DESCRIPTION
These have been migrated to EEST and are soon to be removed in https://github.com/ethereum/tests/pull/1410